### PR TITLE
Allows explicit removal of style sheet by name

### DIFF
--- a/angular-css.js
+++ b/angular-css.js
@@ -374,13 +374,13 @@
         angular.forEach(stylesheets, function(stylesheet) {
           // Get index of current item to be removed based on href
           var index = $rootScope.stylesheets.indexOf($filter('filter')($rootScope.stylesheets, {
-            href: stylesheet.href
+            href: stylesheet.href || stylesheet
           })[0]);
           // Remove stylesheet from scope (if found)
           if (index !== -1) $rootScope.stylesheets.splice(index, 1);
           // Remove stylesheet via media query
           removeViaMediaQuery(stylesheet);
-          $log.debug('$css.remove(): ' + stylesheet.href);
+          $log.debug('$css.remove(): ' + stylesheet.href || stylesheet);
         });
         // Broadcasts custom event for css remove
         $rootScope.$broadcast('$cssRemove', stylesheets, $rootScope.stylesheets);


### PR DESCRIPTION
I added some css stylesheets using add() and found they were not removed by remove().  This appears to fix it.